### PR TITLE
Feat: add queries type definition

### DIFF
--- a/types/luzmo.d.ts
+++ b/types/luzmo.d.ts
@@ -115,6 +115,10 @@ declare namespace luzmo {
     order?: any[];
     limit?: { by: number };
   }
+
+  export interface Queries {
+    queries: Query[];
+  }
 }
 
 declare class luzmo {

--- a/types/luzmo.d.ts
+++ b/types/luzmo.d.ts
@@ -221,7 +221,7 @@ declare class luzmo {
    * - In case of unsynchronized querying, resolves with the results of a query and rejects in case of error.
    *   on the server and rejects in case of error.
    */
-  query(filter: luzmo.Query): Promise<any>;
+  query(filter: luzmo.Query | luzmo.Queries): Promise<any>;
 
   /**
    * Update properties of an entity.


### PR DESCRIPTION
The query method supports both sending a single query, as well as sending a batch of queries simultaneously. This PR adds a type definition for the batch of queries.