### PR TITLE
feat: Add streaming support for AI endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can use this Node.js module to interact with the [Luzmo](https://luzmo.com) 
 
 Include the `@luzmo/nodejs-sdk` npm package in your project. For example, to push data into the platform (triggering real-time dashboard updates):
 
-```
+```js
 const Luzmo = require('@luzmo/nodejs-sdk');
 
 // Connect
@@ -42,10 +42,32 @@ client.create(
 
 See `example-embedding.js` for an example of how to use the API to securely embed dashboards in a web page (with serverside pre-filtering of the data that the end-user can query).
 
+## Streaming Responses
+
+Streaming-compatible responses keep the existing SDK method signatures. When the API responds with `application/x-ndjson`, `application/ndjson`, or `text/event-stream`, the SDK resolves with an async-iterable stream object instead of buffering the full response body. The iterator yields raw UTF-8 text chunks, so callers can parse NDJSON rows or SSE events themselves.
+
+```js
+const stream = await client.create('aiprompt', payload);
+
+const conversationId = stream.headers.get('x-conversation-id');
+
+for await (const chunk of stream) {
+  process.stdout.write(chunk);
+}
+```
+
+The returned stream object exposes:
+
+- `headers`: response headers (for example `x-conversation-id`)
+- `format`: either `ndjson` or `sse`
+- `cancel()`: aborts the unread response body
+
+If the response is regular JSON, the SDK keeps the existing behavior and resolves with the parsed JSON value.
+
 ## TS Types
 
 The types are defined in `types/luzmo.d.ts` and will be expanded as properties are added. However, right now (at time of writing: 25/03/2021) the IDE will prompt the user as to what type to use, but some such as `properties` are still `any` so you should check the documentation to see what to include based on the `resource` you are using. We will continue to add properties to the project.
 
 ## Documentation
 
-The API documentation (available services and methods) can be found [here](http://developer.luzmo.com).
+The API documentation (available services and methods) can be found in the [Luzmo developer documentation](http://developer.luzmo.com).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ The returned stream object exposes:
 - `format`: either `ndjson` or `sse`
 - `cancel()`: aborts the unread response body
 
+The stream class is also exported as `LuzmoStream`, so consumers can distinguish buffered responses from streaming ones:
+
+```js
+const Luzmo = require('@luzmo/nodejs-sdk');
+
+const result = await client.create('iqmessage', payload);
+if (result instanceof Luzmo.LuzmoStream) {
+  for await (const chunk of result) {
+    process.stdout.write(chunk);
+  }
+}
+```
+
 If the response is regular JSON, the SDK keeps the existing behavior and resolves with the parsed JSON value.
 
 ## TS Types

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See `example-embedding.js` for an example of how to use the API to securely embe
 Streaming-compatible responses keep the existing SDK method signatures. When the API responds with `application/x-ndjson`, `application/ndjson`, or `text/event-stream`, the SDK resolves with an async-iterable stream object instead of buffering the full response body. The iterator yields raw UTF-8 text chunks, so callers can parse NDJSON rows or SSE events themselves.
 
 ```js
-const stream = await client.create('aiprompt', payload);
+const stream = await client.create('iqmessage', payload);
 
 const conversationId = stream.headers.get('x-conversation-id');
 
@@ -58,7 +58,7 @@ for await (const chunk of stream) {
 
 The returned stream object exposes:
 
-- `headers`: response headers (for example `x-conversation-id`)
+- `headers`: response headers (some endpoints expose metadata such as `x-conversation-id`)
 - `format`: either `ndjson` or `sse`
 - `cancel()`: aborts the unread response body
 

--- a/src/luzmo-stream.js
+++ b/src/luzmo-stream.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const { TextDecoder } = require("util");
+
+class LuzmoStream {
+  constructor(options) {
+    this.headers = options.headers;
+    this.format = options.format;
+    this._body = options.body;
+    this._controller = options.controller;
+    this._consumed = false;
+  }
+
+  cancel() {
+    if (typeof this._controller?.abort === "function") {
+      this._controller.abort();
+    }
+    if (typeof this._body?.cancel === "function") {
+      this._body.cancel().catch(() => {});
+    }
+  }
+
+  [Symbol.asyncIterator]() {
+    if (this._consumed) {
+      throw new Error("This stream has already been consumed.");
+    }
+    this._consumed = true;
+    return this._iterateText();
+  }
+
+  async *_iterateText() {
+    if (!this._body) {
+      return;
+    }
+
+    const decoder = new TextDecoder();
+
+    if (typeof this._body.getReader === "function") {
+      const reader = this._body.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (!value) {
+            continue;
+          }
+          yield decoder.decode(value, { stream: true });
+        }
+        const trailingChunk = decoder.decode();
+        if (trailingChunk.length > 0) {
+          yield trailingChunk;
+        }
+      } finally {
+        reader.releaseLock?.();
+      }
+
+      return;
+    }
+
+    for await (const chunk of this._body) {
+      if (!chunk) {
+        continue;
+      }
+      if (typeof chunk === "string") {
+        yield chunk;
+        continue;
+      }
+      yield decoder.decode(chunk, { stream: true });
+    }
+
+    const trailingChunk = decoder.decode();
+    if (trailingChunk.length > 0) {
+      yield trailingChunk;
+    }
+  }
+}
+
+module.exports = LuzmoStream;

--- a/src/luzmo.js
+++ b/src/luzmo.js
@@ -7,9 +7,87 @@
 
 "use strict";
 
+const { TextDecoder } = require("util");
+
 const HOST = "https://api.luzmo.com",
       PORT = "443",
       API_VERSION = "0.1.0";
+
+class LuzmoStream {
+  constructor(options) {
+    this.headers = options.headers;
+    this.format = options.format;
+    this._body = options.body;
+    this._controller = options.controller;
+    this._consumed = false;
+  }
+
+  cancel() {
+    if (this._controller) {
+      this._controller.abort();
+    }
+    if (this._body && typeof this._body.cancel === "function") {
+      this._body.cancel().catch(() => {});
+    }
+  }
+
+  [Symbol.asyncIterator]() {
+    if (this._consumed) {
+      throw new Error("This stream has already been consumed.");
+    }
+    this._consumed = true;
+    return this._iterateText();
+  }
+
+  async *_iterateText() {
+    if (!this._body) {
+      return;
+    }
+
+    const decoder = new TextDecoder();
+
+    if (typeof this._body.getReader === "function") {
+      const reader = this._body.getReader();
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) {
+            break;
+          }
+          if (!value) {
+            continue;
+          }
+          yield decoder.decode(value, { stream: true });
+        }
+        const trailingChunk = decoder.decode();
+        if (trailingChunk.length > 0) {
+          yield trailingChunk;
+        }
+      } finally {
+        reader.releaseLock?.();
+      }
+
+      return;
+    }
+
+    for await (const chunk of this._body) {
+      if (!chunk) {
+        continue;
+      }
+      if (typeof chunk === "string") {
+        yield chunk;
+        continue;
+      }
+      yield decoder.decode(chunk, { stream: true });
+    }
+
+    const trailingChunk = decoder.decode();
+    if (trailingChunk.length > 0) {
+      yield trailingChunk;
+    }
+  }
+}
 
 class Luzmo {
   /**
@@ -237,36 +315,32 @@ _onConnect() {
       body: JSON.stringify(data),
     };
 
-    const parseResponseData = (headers, buffer) => {
-      const contentType = headers && headers.get("content-type");
-      const isJSON =
-        !Luzmo._isEmpty(contentType) && contentType.includes("application/json");
-      if (!isJSON) {
-        return buffer;
-      }
-
-      try {
-        return JSON.parse(buffer.toString());
-      } catch (e) {
-        // Invalid JSON payloads are returned as-is for backward compatibility.
-        return buffer;
-      }
-    };
-
     try {
+      const controller = new AbortController();
       const response = await fetch(requestSettings.url, {
         method: requestSettings.method,
         headers: requestSettings.headers,
         body: requestSettings.body,
+        signal: controller.signal,
       });
-      const arrayBuffer = await response.arrayBuffer();
-      const buffer = Buffer.from(arrayBuffer);
+      const responseFormat = Luzmo._getResponseFormat(response.headers);
 
       if (!response.ok) {
-        throw parseResponseData(response.headers, buffer);
+        const buffer = await Luzmo._readResponseBuffer(response);
+        throw Luzmo._parseBufferedResponse(response.headers, buffer);
       }
 
-      return parseResponseData(response.headers, buffer);
+      if (responseFormat === "ndjson" || responseFormat === "sse") {
+        return new LuzmoStream({
+          body: response.body,
+          headers: response.headers,
+          format: responseFormat,
+          controller,
+        });
+      }
+
+      const buffer = await Luzmo._readResponseBuffer(response);
+      return Luzmo._parseBufferedResponse(response.headers, buffer);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "";
       const causeMessage = error instanceof Error && error.cause instanceof Error
@@ -351,6 +425,51 @@ _onConnect() {
  */
   static _compress(payload) {
     return payload;
+  };
+
+  static _getContentType(headers) {
+    const rawContentType = headers && typeof headers.get === "function"
+      ? headers.get("content-type")
+      : headers?.["content-type"];
+    return typeof rawContentType === "string" ? rawContentType.toLowerCase() : "";
+  };
+
+  static _getResponseFormat(headers) {
+    const contentType = Luzmo._getContentType(headers);
+    if (!Luzmo._isEmpty(contentType) && contentType.includes("application/json")) {
+      return "json";
+    }
+    if (contentType.includes("application/x-ndjson") || contentType.includes("application/ndjson")) {
+      return "ndjson";
+    }
+    if (contentType.includes("text/event-stream")) {
+      return "sse";
+    }
+    return "buffer";
+  };
+
+  static _parseBufferedResponse(headers, buffer) {
+    const responseFormat = Luzmo._getResponseFormat(headers);
+
+    if (responseFormat === "ndjson" || responseFormat === "sse") {
+      return buffer.toString("utf8");
+    }
+
+    if (responseFormat !== "json") {
+      return buffer;
+    }
+
+    try {
+      return JSON.parse(buffer.toString());
+    } catch (e) {
+      // Invalid JSON payloads are returned as-is for backward compatibility.
+      return buffer;
+    }
+  };
+
+  static async _readResponseBuffer(response) {
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
   };
 }
 

--- a/src/luzmo.js
+++ b/src/luzmo.js
@@ -340,6 +340,9 @@ _onConnect() {
       }
 
       const buffer = await Luzmo._readResponseBuffer(response);
+      if (buffer.length === 0) {
+        return undefined;
+      }
       return Luzmo._parseBufferedResponse(response.headers, buffer);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "";

--- a/src/luzmo.js
+++ b/src/luzmo.js
@@ -7,87 +7,11 @@
 
 "use strict";
 
-const { TextDecoder } = require("util");
+const LuzmoStream = require("./luzmo-stream");
 
 const HOST = "https://api.luzmo.com",
       PORT = "443",
       API_VERSION = "0.1.0";
-
-class LuzmoStream {
-  constructor(options) {
-    this.headers = options.headers;
-    this.format = options.format;
-    this._body = options.body;
-    this._controller = options.controller;
-    this._consumed = false;
-  }
-
-  cancel() {
-    if (this._controller) {
-      this._controller.abort();
-    }
-    if (this._body && typeof this._body.cancel === "function") {
-      this._body.cancel().catch(() => {});
-    }
-  }
-
-  [Symbol.asyncIterator]() {
-    if (this._consumed) {
-      throw new Error("This stream has already been consumed.");
-    }
-    this._consumed = true;
-    return this._iterateText();
-  }
-
-  async *_iterateText() {
-    if (!this._body) {
-      return;
-    }
-
-    const decoder = new TextDecoder();
-
-    if (typeof this._body.getReader === "function") {
-      const reader = this._body.getReader();
-
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
-          if (!value) {
-            continue;
-          }
-          yield decoder.decode(value, { stream: true });
-        }
-        const trailingChunk = decoder.decode();
-        if (trailingChunk.length > 0) {
-          yield trailingChunk;
-        }
-      } finally {
-        reader.releaseLock?.();
-      }
-
-      return;
-    }
-
-    for await (const chunk of this._body) {
-      if (!chunk) {
-        continue;
-      }
-      if (typeof chunk === "string") {
-        yield chunk;
-        continue;
-      }
-      yield decoder.decode(chunk, { stream: true });
-    }
-
-    const trailingChunk = decoder.decode();
-    if (trailingChunk.length > 0) {
-      yield trailingChunk;
-    }
-  }
-}
 
 class Luzmo {
   /**
@@ -477,3 +401,4 @@ _onConnect() {
 }
 
 module.exports = Luzmo;
+module.exports.LuzmoStream = LuzmoStream;

--- a/test/luzmo.test.js
+++ b/test/luzmo.test.js
@@ -221,6 +221,17 @@ test("delete(resource, id, properties) sends delete payload", async () => {
   );
 });
 
+test("empty successful responses resolve to undefined", async () => {
+  await withApiServer(
+    async () => ({ status: 204 }),
+    async ({ client }) => {
+      const response = await client.delete("dashboard", "dashboard-id");
+
+      assert.equal(response, undefined);
+    },
+  );
+});
+
 test("associate(resource, id, association) sends resource association payload", async () => {
   const association = { role: "dataset", id: "dataset-id" };
   await withApiServer(
@@ -406,22 +417,6 @@ test("returns server-sent event responses as async iterables", async () => {
       }
 
       assert.equal(chunks.join(""), raw);
-    },
-  );
-});
-
-test("throws NDJSON error payloads as UTF-8 strings", async () => {
-  const raw = '{"error":"Something failed"}\n';
-  await withApiServer(
-    async () => ({
-      status: 400,
-      headers: { "content-type": "application/x-ndjson; charset=utf-8" },
-      body: Buffer.from(raw),
-    }),
-    async ({ client }) => {
-      await assert.rejects(async () => {
-        await client.create("iqmessage", { prompt: "fail" });
-      }, (error) => error === raw);
     },
   );
 });

--- a/test/luzmo.test.js
+++ b/test/luzmo.test.js
@@ -11,6 +11,10 @@ function createClient(options = {}) {
   });
 }
 
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function withApiServer(handler, run) {
   return new Promise((resolve, reject) => {
     const requests = [];
@@ -33,6 +37,49 @@ function withApiServer(handler, run) {
         res.setHeader(headerName, headerValue);
       }
       res.end(response?.body ?? Buffer.alloc(0));
+    });
+
+    server.listen(0, "127.0.0.1", async () => {
+      const address = server.address();
+      const client = createClient({
+        host: "http://127.0.0.1",
+        port: String(address.port),
+      });
+
+      try {
+        await run({ client, requests });
+        server.close((closeError) => (closeError ? reject(closeError) : resolve()));
+      } catch (error) {
+        server.close(() => reject(error));
+      }
+    });
+  });
+}
+
+function withStreamingApiServer(handler, run) {
+  return new Promise((resolve, reject) => {
+    const requests = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      await new Promise((requestResolve) => req.on("end", requestResolve));
+
+      const request = {
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      };
+      requests.push(request);
+
+      try {
+        await handler({ request, requests, response: res, requestIndex: requests.length - 1 });
+        if (!res.writableEnded && !res.destroyed) {
+          res.end();
+        }
+      } catch (error) {
+        res.destroy(error);
+      }
     });
 
     server.listen(0, "127.0.0.1", async () => {
@@ -297,6 +344,84 @@ test("returns raw payload for non-JSON content-type", async () => {
     async ({ client }) => {
       const result = await client.get("dashboard", {});
       assert.deepEqual(result, raw);
+    },
+  );
+});
+
+test("returns NDJSON responses as async iterables with headers", async () => {
+  let secondChunkSent = false;
+  const raw = '{"chunk":"hello"}\n{"done":true}\n';
+
+  await withStreamingApiServer(
+    async ({ response }) => {
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/x-ndjson; charset=utf-8");
+      response.setHeader("x-conversation-id", "conv-123");
+      response.write('{"chunk":"hello"}\n');
+      await delay(25);
+      secondChunkSent = true;
+      response.end('{"done":true}\n');
+    },
+    async ({ client }) => {
+      const stream = await client.create("iqmessage", { prompt: "Say hello" });
+
+      assert.equal(stream.format, "ndjson");
+      assert.equal(stream.headers.get("x-conversation-id"), "conv-123");
+      assert.equal(typeof stream.cancel, "function");
+      assert.equal(typeof stream[Symbol.asyncIterator], "function");
+      assert.equal(secondChunkSent, false, "stream should be returned before the response body finishes");
+
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      assert.equal(chunks.join(""), raw);
+      assert.equal(secondChunkSent, true);
+    },
+  );
+});
+
+test("returns server-sent event responses as async iterables", async () => {
+  const raw = 'event: update\ndata: {"type":"text_delta","delta":"hello"}\n\ndata: [DONE]\n\n';
+
+  await withStreamingApiServer(
+    async ({ response }) => {
+      response.statusCode = 200;
+      response.setHeader("content-type", "text/event-stream; charset=utf-8");
+      response.write("event: update\n");
+      response.write('data: {"type":"text_delta",');
+      await delay(5);
+      response.write('"delta":"hello"}\n\n');
+      response.end("data: [DONE]\n\n");
+    },
+    async ({ client }) => {
+      const stream = await client.create("aiprompt", { stream: true });
+
+      assert.equal(stream.format, "sse");
+
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      assert.equal(chunks.join(""), raw);
+    },
+  );
+});
+
+test("throws NDJSON error payloads as UTF-8 strings", async () => {
+  const raw = '{"error":"Something failed"}\n';
+  await withApiServer(
+    async () => ({
+      status: 400,
+      headers: { "content-type": "application/x-ndjson; charset=utf-8" },
+      body: Buffer.from(raw),
+    }),
+    async ({ client }) => {
+      await assert.rejects(async () => {
+        await client.create("iqmessage", { prompt: "fail" });
+      }, (error) => error === raw);
     },
   );
 });

--- a/test/luzmo.test.js
+++ b/test/luzmo.test.js
@@ -376,6 +376,8 @@ test("returns NDJSON responses as async iterables with headers", async () => {
     async ({ client }) => {
       const stream = await client.create("iqmessage", { prompt: "Say hello" });
 
+      assert.equal(typeof Luzmo.LuzmoStream, "function");
+      assert.equal(stream instanceof Luzmo.LuzmoStream, true);
       assert.equal(stream.format, "ndjson");
       assert.equal(stream.headers.get("x-conversation-id"), "conv-123");
       assert.equal(typeof stream.cancel, "function");

--- a/types/luzmo.d.ts
+++ b/types/luzmo.d.ts
@@ -7,17 +7,19 @@ declare namespace luzmo {
    * Described the Options object
    * @attr api_key
    * @attr api_token
+   * @attr api_version (Optional)
    * @attr host (Optional)
    * @attr port (Optional)
    */
   export interface Options {
     api_key: UUID;
     api_token: string;
+    api_version?: string;
     host?: string;
     port?: string;
   }
 
-  export type Resource =
+  export type KnownResource =
     | "authorization"
     | "user"
     | "group"
@@ -39,6 +41,21 @@ declare namespace luzmo {
     | "collection"
     | "aichart"
     | "export";
+
+  export type Resource = KnownResource | (string & {});
+
+  export type StreamFormat = "ndjson" | "sse";
+
+  export interface StreamHeaders {
+    get(name: string): string | null;
+    has(name: string): boolean;
+  }
+
+  export interface Stream extends AsyncIterable<string> {
+    headers: StreamHeaders;
+    format: StreamFormat;
+    cancel(): void;
+  }
 
   export type Role =
     | "Accounts"

--- a/types/luzmo.d.ts
+++ b/types/luzmo.d.ts
@@ -57,6 +57,21 @@ declare namespace luzmo {
     cancel(): void;
   }
 
+  export interface StreamOptions {
+    headers: StreamHeaders;
+    format: StreamFormat;
+    body?: any;
+    controller?: any;
+  }
+
+  export class LuzmoStream implements Stream {
+    constructor(options: StreamOptions);
+    headers: StreamHeaders;
+    format: StreamFormat;
+    cancel(): void;
+    [Symbol.asyncIterator](): AsyncIterableIterator<string>;
+  }
+
   export type Role =
     | "Accounts"
     | "Aggregations"


### PR DESCRIPTION
- Add streaming support for ai endpoints returning `application/ndjson` or `text/event-stream`
- Tested by running it against internal test suite https://github.com/cumulio-internal/visuals/pull/6288